### PR TITLE
[0.3.7] clearLine 및 clearGameScreen 함수 생성 및 적용

### DIFF
--- a/main.c
+++ b/main.c
@@ -24,8 +24,6 @@ int main()
 	srand(time(NULL));					/* initialize random generator */
 
 	do {
-		clrscr();					/* clear screen */
-
 		writesat(0, 0, 15, "   ____          __      ");
 		writesat(0, 1, 15, "  / __/__  ___ _/ /_____ ");
 		writesat(0, 2, 7, " _\\ \\/ _ \\/ _ `/  '_/ -_)");
@@ -92,6 +90,8 @@ int main()
 			createFruit(screen, &fruit);
 		}
 
+		clearGameScreen(screen);
+
 		/* screen painting occurred here */
 		writecat(fruit.pos.x, fruit.pos.y, fruit.color, FRUIT_SHAPE);			/* fruit */
 		writecat(snake.body[0].x, snake.body[0].y, 15, HEAD_SHAPE);	/* snake's head */
@@ -104,8 +104,6 @@ int main()
 	} while (!quit);
 
 	cursor(1);					/* turn the cursor back on */
-	clrscr();
 
 	return 0;
 }
-

--- a/ui.c
+++ b/ui.c
@@ -55,3 +55,10 @@ void writesat(int x, int y, int c, const char * s) {
 	textcolor(c);
 	puts(s);
 }
+
+void clearLine(CELL clearPointCell, int length)
+{
+	COORD clearPoint = { clearPointCell.x, clearPointCell.y };
+	unsigned long tmp;
+	FillConsoleOutputCharacter(GetStdHandle(STD_OUTPUT_HANDLE), '\0', length, clearPoint, &tmp);
+}

--- a/ui.c
+++ b/ui.c
@@ -45,11 +45,6 @@ int getMaxColorValue() {
 	return 16;
 }
 
-void clrscr()
-{
-	system("cls");
-}
-
 void writesat(int x, int y, int c, const char * s) {
 	gotoxy(x, y);
 	textcolor(c);
@@ -60,5 +55,19 @@ void clearLine(CELL clearPointCell, int length)
 {
 	COORD clearPoint = { clearPointCell.x, clearPointCell.y };
 	unsigned long tmp;
+
 	FillConsoleOutputCharacter(GetStdHandle(STD_OUTPUT_HANDLE), '\0', length, clearPoint, &tmp);
+}
+
+void clearGameScreen(SCREEN screen)
+{
+	int i;
+	CELL gameStartPoint = { screen.startPoint.x + 2, screen.startPoint.y + 1 };
+	CELL gameEndPoint = { screen.endPoint.x - 2, screen.endPoint.y - 1 };
+
+	for (i = gameStartPoint.y; i < gameEndPoint.y; i++)
+	{
+		CELL clearPoint = { gameStartPoint.x, i };
+		clearLine(clearPoint, gameEndPoint.x - gameStartPoint.x);
+	}
 }

--- a/ui.c
+++ b/ui.c
@@ -68,6 +68,7 @@ void clearGameScreen(SCREEN screen)
 	for (i = gameStartPoint.y; i < gameEndPoint.y; i++)
 	{
 		CELL clearPoint = { gameStartPoint.x, i };
-		clearLine(clearPoint, gameEndPoint.x - gameStartPoint.x);
+		int eraseLength = gameEndPoint.x - gameStartPoint.x; 
+		clearLine(clearPoint, eraseLength);
 	}
 }

--- a/ui.h
+++ b/ui.h
@@ -31,11 +31,11 @@ void createScreen(SCREEN* screen);
 /* returns the total number of color supported */
 int getMaxColorValue();
 
-/* clear the screen */
-void clrscr();
-
 /* display a string at position (x,y) using color c */
 void writesat(int x, int y, int c, const char * s);
 
 /* clear one line from 'clearpointCell' by 'length'*/
 void clearLine(CELL clearPointCell, int length);
+
+/* clear the game space */
+void clearGameScreen(SCREEN screen);

--- a/ui.h
+++ b/ui.h
@@ -36,3 +36,6 @@ void clrscr();
 
 /* display a string at position (x,y) using color c */
 void writesat(int x, int y, int c, const char * s);
+
+/* clear one line from 'clearpointCell' by 'length'*/
+void clearLine(CELL clearPointCell, int length);


### PR DESCRIPTION
1. 게임 공간 한 줄을 지우는 clearLine 함수 생성
2. 기존의 clrscr 함수를 clearGameScreen 함수로 변경 후 clearLine 함수를 이용해 구현
3. 메인 코드에서 clrscr이 쓰이던 부분을 지우고 clearGameScreen 위치 새로 지정
4. clearGameScreen 함수에 실수로 누락한 코드 수정