### PR TITLE
[0.3.8] updateHead 함수 구현 및 사용

### DIFF
--- a/main.c
+++ b/main.c
@@ -70,15 +70,6 @@ int main()
 
 		moveSnake(&snake);
 
-		/* update the head's coordinates */
-		switch (snake.dir) {
-		case up: snake.body[0].y--; break;
-		case down: snake.body[0].y++; break;
-			/* x always a multiple of 2, since it was inited at 0 */
-		case left: snake.body[0].x -= 2; break;
-		case right: snake.body[0].x += 2; break;
-		}
-
 		/* wrap the snake at screen boundaries */
 		if (snake.body[0].y < 4)      snake.body[0].y = screen.height - 2;
 		if (snake.body[0].y > screen.height - 1) snake.body[0].y = 4;

--- a/object.c
+++ b/object.c
@@ -159,11 +159,11 @@ void changeDirRight(SNAKE* snake)
 
 void moveSnake(SNAKE *snake)
 {
-	UpdateBody(snake);
+	updateBody(snake);
 	updateHead(snake);
 }
 
-void UpdateBody(SNAKE *snake) 
+void updateBody(SNAKE *snake) 
 {
 	int i;
 	for (i = snake->length - 1; i > 0; i--) {

--- a/object.c
+++ b/object.c
@@ -160,6 +160,7 @@ void changeDirRight(SNAKE* snake)
 void moveSnake(SNAKE *snake)
 {
 	UpdateBody(snake);
+	updateHead(snake);
 }
 
 void UpdateBody(SNAKE *snake) 
@@ -167,6 +168,25 @@ void UpdateBody(SNAKE *snake)
 	int i;
 	for (i = snake->length - 1; i > 0; i--) {
 		snake->body[i] = snake->body[i - 1];
+	}
+}
+
+void updateHead(SNAKE* snake)
+{
+	switch (snake->dir)
+	{
+	case up:
+		snake->body[0].y--;
+		break;
+	case down:
+		snake->body[0].y++;
+		break;
+	case left:
+		snake->body[0].x -= 2;
+		break;
+	case right:
+		snake->body[0].x += 2;
+		break;
 	}
 }
 

--- a/object.h
+++ b/object.h
@@ -74,8 +74,11 @@ void moveSnake(SNAKE *snake);
 /* update the snake body based on its head */
 void UpdateBody(SNAKE *snake);
 
+void updateHead(SNAKE* snake);
+
 bool isEven(int number);
 
 void createFruit(SCREEN screen, FRUIT* fruit);
 
 void createSnake(SCREEN screen, SNAKE* snake);
+

--- a/object.h
+++ b/object.h
@@ -72,7 +72,7 @@ void changeDirRight(SNAKE* snake);
 void moveSnake(SNAKE *snake);
 
 /* update the snake body based on its head */
-void UpdateBody(SNAKE *snake);
+void updateBody(SNAKE *snake);
 
 void updateHead(SNAKE* snake);
 


### PR DESCRIPTION
1. main.c에서 머리의 방향에 따라 머리를 이동시키는 switch 조건문 삭제
object.h에 updateHead 함수 선언 후, object.c에서 머리를 이동시키는 함수인 updateHead 구현
미리 만들어져 있는 moveSnake 함수에서 updateHead 함수 사용
2. object.h와 object.c의 UpdateBody 함수를 updateBody로 함수명 변경