### PR TITLE
[1.2.3] main 함수에서의 충돌 함수들 호출

### DIFF
--- a/main.c
+++ b/main.c
@@ -61,15 +61,7 @@ int main()
 		moveSnake(&snake);
 
 		quit = isCollideBoundary(snake.body[0], &screen);
-
-
-		/* snake eats fruits? */
-		if (snake.body[0].x == fruit.pos.x && snake.body[0].y == fruit.pos.y) {
-			snake.length++;		/* it grows */
-			score++;		/* and update the score */
-			/* regenerate a new fruit */
-			createFruit(screen, &fruit);
-		}
+                isCollideFruit(&snake, &fruit, screen, &score);
 
 		clearGameScreen(screen);
 

--- a/main.c
+++ b/main.c
@@ -60,11 +60,8 @@ int main()
 
 		moveSnake(&snake);
 
-		/* wrap the snake at screen boundaries */
-		if (snake.body[0].y < 4)      snake.body[0].y = screen.height - 2;
-		if (snake.body[0].y > screen.height - 1) snake.body[0].y = 4;
-		if (snake.body[0].x < 0)      snake.body[0].x = screen.width - 2;
-		if (snake.body[0].x > screen.width - 1) snake.body[0].x = 0;
+		quit = isCollideBoundary(snake.body[0], &screen);
+
 
 		/* snake eats fruits? */
 		if (snake.body[0].x == fruit.pos.x && snake.body[0].y == fruit.pos.y) {

--- a/main.c
+++ b/main.c
@@ -61,7 +61,10 @@ int main()
 		moveSnake(&snake);
 
 		quit = isCollideBoundary(snake.body[0], &screen);
-		quit = isCollideBody(&snake);
+		if (quit == false)
+		{
+			quit = isCollideBody(&snake);
+		}
                 isCollideFruit(&snake, &fruit, screen, &score);
 
 		clearGameScreen(screen);

--- a/main.c
+++ b/main.c
@@ -61,6 +61,7 @@ int main()
 		moveSnake(&snake);
 
 		quit = isCollideBoundary(snake.body[0], &screen);
+		quit = isCollideBody(&snake);
                 isCollideFruit(&snake, &fruit, screen, &score);
 
 		clearGameScreen(screen);

--- a/object.c
+++ b/object.c
@@ -74,7 +74,7 @@ bool isCollideBoundary(CELL snakePos, SCREEN* screen)
 	{
 		return true;
 	}
-	else if (rightMax(screen->endPoint.y, snakePos.y))
+	else if (rightMax(screen->endPoint.y - 1, snakePos.y))
 	{
 		return true;
 	}
@@ -82,7 +82,7 @@ bool isCollideBoundary(CELL snakePos, SCREEN* screen)
 	{
 		return true;
 	}
-	else if (rightMax(screen->endPoint.x, snakePos.x))
+	else if (rightMax(screen->endPoint.x - 3, snakePos.x))
 	{
 		return true;
 	}


### PR DESCRIPTION
1. main 함수에서 기존의 경계충돌 조건문 삭제 및 경계충돌 함수(isCollideBoundary) 호출
2. main 함수에서 자가충돌 함수(isCollideBody) 호출
3. main 함수에서의 기존의 과일충돌 조건문 삭제 및 과일충돌 함수(isCollideFruit) 호출
4. 변수 quit 하나만 사용해서 나타나는 오류 해결(조건문 추가)
5. 맵의 경계 충돌에 사용되는 범위 수정