### PR TITLE
[0.3.9] drawObjects 함수 변경 및 SCORE_COLOR 이름 변경

### DIFF
--- a/object.c
+++ b/object.c
@@ -11,12 +11,6 @@ void gotoxy(int x, int y) {
 	SetConsoleCursorPosition(hConsoleOutput, Cursor_an_Pos);
 }
 
-void writecat(int x, int y, int c, const char ch) {
-	gotoxy(x, y);
-	textcolor(c);
-	putchar(ch);
-}
-
 	bool rightMax(int a, int b)
 	{
 		return (a <= b);

--- a/object.c
+++ b/object.c
@@ -11,244 +11,246 @@ void gotoxy(int x, int y) {
 	SetConsoleCursorPosition(hConsoleOutput, Cursor_an_Pos);
 }
 
-	bool rightMax(int a, int b)
+bool rightMax(int a, int b)
+{
+	return (a <= b);
+}
+bool isSameValue(int leftValue, int rightValue)
+{
+	return (leftValue == rightValue);
+}
+bool isSamePosition(CELL* leftPos, CELL* rightPos)
+{
+	return (isSameValue(leftPos->x, rightPos->x) && isSameValue(leftPos->y, rightPos->y));
+}
+bool isCollideBoundary(CELL snakePos, SCREEN* screen)
+{
+	if (rightMax(snakePos.y, screen->startPoint.y))
 	{
-		return (a <= b);
+		return true;
 	}
-	bool isSameValue(int leftValue, int rightValue)
+	else if (rightMax(screen->endPoint.y - 1, snakePos.y))
 	{
-		return (leftValue == rightValue);
+		return true;
 	}
-	bool isSamePosition(CELL* leftPos, CELL* rightPos)
+	else if (rightMax(snakePos.x, screen->startPoint.x))
 	{
-		return (isSameValue(leftPos->x, rightPos->x) && isSameValue(leftPos->y, rightPos->y));
+		return true;
 	}
-	bool isCollideBoundary(CELL snakePos, SCREEN* screen)
+	else if (rightMax(screen->endPoint.x - 3, snakePos.x))
 	{
-		if (rightMax(snakePos.y, screen->startPoint.y))
-		{
-			return true;
-		}
-		else if (rightMax(screen->endPoint.y - 1, snakePos.y))
-		{
-			return true;
-		}
-		else if (rightMax(snakePos.x, screen->startPoint.x))
-		{
-			return true;
-		}
-		else if (rightMax(screen->endPoint.x - 3, snakePos.x))
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return true;
 	}
-
-	bool isCollideBody(SNAKE* snake)
+	else
 	{
-		int i = 0;
-		for (i = 1; i < snake->length; i++)
-		{
-			if (isSamePosition(&snake->body[0], &snake->body[i]))
-			{
-				return true;
-			}
-		}
 		return false;
 	}
+}
 
-	void isCollideFruit(SNAKE* snake, FRUIT* fruit, SCREEN screen, int* score)
+bool isCollideBody(SNAKE* snake)
+{
+	int i = 0;
+	for (i = 1; i < snake->length; i++)
 	{
-		if (isSamePosition(&snake->body[0], &fruit->pos))
-		{
-			snake->length++;
-			(*score)++;
-			createFruit(screen, fruit);
-		}
-	}
-
-	bool isKeyInput(char* inputValue)
-	{
-		if (_kbhit())
-		{
-			*inputValue = toupper(_getch());
-			return true;
-		}
-		return false;
-	}
-
-	bool isDirUp(SNAKE* snake)
-	{
-		if (snake->dir == up)
+		if (isSamePosition(&snake->body[0], &snake->body[i]))
 		{
 			return true;
 		}
-		return false;
 	}
+	return false;
+}
 
-	bool isDirDown(SNAKE* snake)
+void isCollideFruit(SNAKE* snake, FRUIT* fruit, SCREEN screen, int* score)
+{
+	if (isSamePosition(&snake->body[0], &fruit->pos))
 	{
-		if (snake->dir == down)
-		{
-			return true;
-		}
-		return false;
+		snake->length++;
+		(*score)++;
+		createFruit(screen, fruit);
 	}
+}
 
-	bool isDirLeft(SNAKE* snake)
+bool isKeyInput(char* inputValue)
+{
+	if (_kbhit())
 	{
-		if (snake->dir == left)
-		{
-			return true;
-		}
-		return false;
+		*inputValue = toupper(_getch());
+		return true;
 	}
+	return false;
+}
 
-	bool isDirRight(SNAKE* snake)
+bool isDirUp(SNAKE* snake)
+{
+	if (snake->dir == up)
 	{
-		if (snake->dir == right)
-		{
-			return true;
-		}
-		return false;
+		return true;
 	}
+	return false;
+}
 
-	bool isDirUpOrDown(SNAKE* snake)
+bool isDirDown(SNAKE* snake)
+{
+	if (snake->dir == down)
 	{
-		return (isDirUp(snake) || isDirDown(snake));
+		return true;
 	}
+	return false;
+}
 
-	bool isDirLeftOrRight(SNAKE* snake)
+bool isDirLeft(SNAKE* snake)
+{
+	if (snake->dir == left)
 	{
-		return (isDirLeft(snake) || isDirRight(snake));
+		return true;
 	}
+	return false;
+}
 
-	void changeDirUp(SNAKE* snake)
+bool isDirRight(SNAKE* snake)
+{
+	if (snake->dir == right)
 	{
-		if (!isDirUpOrDown(snake))
-		{
-			snake->dir = up;
-		}
+		return true;
 	}
+	return false;
+}
 
-	void changeDirDown(SNAKE* snake)
+bool isDirUpOrDown(SNAKE* snake)
+{
+	return (isDirUp(snake) || isDirDown(snake));
+}
+
+bool isDirLeftOrRight(SNAKE* snake)
+{
+	return (isDirLeft(snake) || isDirRight(snake));
+}
+
+void changeDirUp(SNAKE* snake)
+{
+	if (!isDirUpOrDown(snake))
 	{
-		if (!isDirUpOrDown(snake))
-		{
-			snake->dir = down;
-		}
+		snake->dir = up;
 	}
+}
 
-	void changeDirLeft(SNAKE* snake)
+void changeDirDown(SNAKE* snake)
+{
+	if (!isDirUpOrDown(snake))
 	{
-		if (!isDirLeftOrRight(snake))
-		{
-			snake->dir = left;
-		}
+		snake->dir = down;
 	}
+}
 
-	void changeDirRight(SNAKE* snake)
+void changeDirLeft(SNAKE* snake)
+{
+	if (!isDirLeftOrRight(snake))
 	{
-		if (!isDirLeftOrRight(snake))
-		{
-			snake->dir = right;
-		}
+		snake->dir = left;
 	}
+}
 
-	void moveSnake(SNAKE *snake)
+void changeDirRight(SNAKE* snake)
+{
+	if (!isDirLeftOrRight(snake))
 	{
-		updateBody(snake);
-		updateHead(snake);
-	}
-
-	void updateBody(SNAKE *snake)
-	{
-		int i;
-		for (i = snake->length - 1; i > 0; i--) {
-			snake->body[i] = snake->body[i - 1];
-		}
-	}
-
-	void updateHead(SNAKE* snake)
-	{
-		switch (snake->dir)
-		{
-		case up:
-			snake->body[0].y--;
-			break;
-		case down:
-			snake->body[0].y++;
-			break;
-		case left:
-			snake->body[0].x -= 2;
-			break;
-		case right:
-			snake->body[0].x += 2;
-			break;
-		}
-	}
-
-	bool isEven(int number)
-	{
-		if (number % 2 == 0)
-		{
-			return true;
-		}
-
-		return false;
-	}
-
-	void createFruit(SCREEN screen, FRUIT* fruit)
-	{
-		CELL strP = { screen.startPoint.x + 2, screen.startPoint.y + 1 };
-		CELL endP = { screen.endPoint.x - 2, screen.endPoint.y - 1 };
-		int maxColorValue;
-		int tmpX; //for fruit->x
-
-		tmpX = rand() % (endP.x - strP.x);
-
-		if (!isEven(tmpX))
-		{
-			tmpX -= 1;
-		}
-
-		fruit->pos.x = strP.x + tmpX;
-		fruit->pos.y = strP.y + rand() % (endP.y - strP.y);
-
-		maxColorValue = getMaxColorValue();
-		fruit->color = 1 + (rand() % (maxColorValue - 1));
-	}
-
-	void createSnake(SCREEN screen, SNAKE* snake)
-	{
-		int centerX = ((screen.endPoint.x + screen.startPoint.x) / 2);
-		int centerY = ((screen.endPoint.y + screen.startPoint.y) / 2);
-		CELL center = { centerX, centerY };
-
-		snake->body[0] = center;
-		center.x -= 2;
-		snake->body[1] = center;
-
 		snake->dir = right;
-		snake->length = 2;
 	}
+}
 
-	void drawChar(CELL pos, int color, const char character) {
-		gotoxy(pos.x, pos.y);
-		textcolor(color);
-		putchar(character);
+void moveSnake(SNAKE *snake)
+{
+	updateBody(snake);
+	updateHead(snake);
+}
+
+void updateBody(SNAKE *snake)
+{
+	int i;
+	for (i = snake->length - 1; i > 0; i--) {
+		snake->body[i] = snake->body[i - 1];
 	}
+}
 
-	void drawObjects(SNAKE snake, FRUIT fruit)
+void updateHead(SNAKE* snake)
+{
+	switch (snake->dir)
 	{
-		int i;
-
-		drawChar(fruit.pos, fruit.color, FRUIT_SHAPE);			/* fruit */
-		drawChar(snake.body[0], HEAD_COLOR, HEAD_SHAPE);		/* snake's head */
-		for (i = 1; i < snake.length; i++) {
-			drawChar(snake.body[i], BODY_COLOR, BODY_SHAPE);	/* snake's body */
-		}
+	case up:
+		snake->body[0].y--;
+		break;
+	case down:
+		snake->body[0].y++;
+		break;
+	case left:
+		snake->body[0].x -= 2;
+		break;
+	case right:
+		snake->body[0].x += 2;
+		break;
 	}
+}
+
+bool isEven(int number)
+{
+	if (number % 2 == 0)
+	{
+		return true;
+	}
+
+	return false;
+}
+
+void createFruit(SCREEN screen, FRUIT* fruit)
+{
+	CELL strP = { screen.startPoint.x + 2, screen.startPoint.y + 1 };
+	CELL endP = { screen.endPoint.x - 2, screen.endPoint.y - 1 };
+	int maxColorValue;
+	int tmpX; //for fruit->x
+
+	tmpX = rand() % (endP.x - strP.x);
+
+	if (!isEven(tmpX))
+	{
+		tmpX -= 1;
+	}
+
+	fruit->pos.x = strP.x + tmpX;
+	fruit->pos.y = strP.y + rand() % (endP.y - strP.y);
+
+	maxColorValue = getMaxColorValue();
+	fruit->color = 1 + (rand() % (maxColorValue - 1));
+}
+
+void createSnake(SCREEN screen, SNAKE* snake)
+{
+	int centerX = ((screen.endPoint.x + screen.startPoint.x) / 2);
+	int centerY = ((screen.endPoint.y + screen.startPoint.y) / 2);
+	CELL center = { centerX, centerY };
+
+	snake->body[0] = center;
+	center.x -= 2;
+	snake->body[1] = center;
+
+	snake->dir = right;
+	snake->length = 2;
+}
+
+void drawChar(CELL pos, int color, const char character) 
+{
+	gotoxy(pos.x, pos.y);
+	textcolor(color);
+	putchar(character);
+}
+
+void drawObjects(SNAKE snake, FRUIT fruit)
+{
+	int i;
+
+	for (i = 1; i < snake.length; i++) {
+		drawChar(snake.body[i], BODY_COLOR, BODY_SHAPE);	/* snake's body */
+	}
+	drawChar(snake.body[0], HEAD_COLOR, HEAD_SHAPE);		/* snake's head */
+	drawChar(fruit.pos, fruit.color, FRUIT_SHAPE);			/* fruit */
+}
+

--- a/object.c
+++ b/object.c
@@ -253,6 +253,6 @@ void drawObjects(SNAKE snake, FRUIT fruit)
 	drawChar(snake.body[0], HEAD_COLOR, HEAD_SHAPE);		/* snake's head */
 	drawChar(fruit.pos, fruit.color, FRUIT_SHAPE);			/* fruit */
 
-	textcolor(15);							/* back to normal color */
+	textcolor(TEXT_COLOR);						/* back to normal color */
 }
 

--- a/object.c
+++ b/object.c
@@ -252,5 +252,7 @@ void drawObjects(SNAKE snake, FRUIT fruit)
 	}
 	drawChar(snake.body[0], HEAD_COLOR, HEAD_SHAPE);		/* snake's head */
 	drawChar(fruit.pos, fruit.color, FRUIT_SHAPE);			/* fruit */
+
+	textcolor(15);							/* back to normal color */
 }
 

--- a/object.h
+++ b/object.h
@@ -30,8 +30,6 @@ typedef struct snake
 /* move the cursor to position (x,y) */
 void gotoxy(int x, int y);
 
-void writecat(int x, int y, int c, const char ch);
-
 bool rightMax(int a, int b);
 
 bool isSameValue(int leftValue, int rightValue);

--- a/ui.c
+++ b/ui.c
@@ -70,7 +70,7 @@ void clearGameScreen(SCREEN screen)
 void drawScore(int score) 
 {
 	gotoxy(37, 2);
-	textcolor(SCORE_COLOR);
+	textcolor(TEXT_COLOR);
 	printf("%d", score);
 }
 

--- a/ui.h
+++ b/ui.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define SCORE_COLOR 15
+#define TEXT_COLOR 15
 
 typedef struct cell
 {


### PR DESCRIPTION
1. 먼저, 실수로 지워지지 않은 writecat 함수 삭제
2. #36 이슈의 문제로 인해 과일이 보이지 않는 문제 해결을 위해 출력 순서 변경
3. 2번의 변경으로 인해 UI 및 종료 메세지가 과일 색으로 출력되는 버그를 textcolor함수를 이용해 수정
4. textcolor의 인자로 SCORE_COLOR를 사용. 용도 확장에 따라 이름을 TEXT_COLOR로 변경