### PR TITLE
[1.4.1] 게임 오버 시 화면 조정

### DIFF
--- a/main.c
+++ b/main.c
@@ -79,7 +79,7 @@ int main()
 		}
 
 		/* screen painting occurred here */
-		drawObjects(snake, fruit);
+		drawObjects(snake, fruit, quit);
 
 		Sleep(50);				/* slow down a bit */
 	} while (!quit);

--- a/main.c
+++ b/main.c
@@ -72,7 +72,11 @@ int main()
 
                 isCollideFruit(&snake, &fruit, screen, &score);
 
-		clearGameScreen(screen);
+		/* clear the game space */
+		if (quit == false)
+		{
+			clearGameScreen(screen);
+		}
 
 		/* screen painting occurred here */
 		drawObjects(snake, fruit);

--- a/object.c
+++ b/object.c
@@ -248,7 +248,7 @@ void drawObjects(SNAKE snake, FRUIT fruit, int quit)
 	int i;
 	if (quit) 
 	{
-		drawChar(snake.body[1], 12, HEAD_SHAPE);		/* dead snake's head */
+		drawChar(snake.body[1], QUIT_COLOR, HEAD_SHAPE);	/* dead snake's head */
 		textcolor(TEXT_COLOR);					/* back to normal color */
 		return;
 	}

--- a/object.c
+++ b/object.c
@@ -243,16 +243,20 @@ void drawChar(CELL pos, int color, const char character)
 	putchar(character);
 }
 
-void drawObjects(SNAKE snake, FRUIT fruit)
+void drawObjects(SNAKE snake, FRUIT fruit, int quit)
 {
 	int i;
+	if (quit) 
+	{
+		drawChar(snake.body[1], 12, HEAD_SHAPE);		/* dead snake's head */
+		textcolor(TEXT_COLOR);					/* back to normal color */
+		return;
+	}
 
 	for (i = 1; i < snake.length; i++) {
 		drawChar(snake.body[i], BODY_COLOR, BODY_SHAPE);	/* snake's body */
 	}
 	drawChar(snake.body[0], HEAD_COLOR, HEAD_SHAPE);		/* snake's head */
 	drawChar(fruit.pos, fruit.color, FRUIT_SHAPE);			/* fruit */
-
-	textcolor(TEXT_COLOR);						/* back to normal color */
 }
 

--- a/object.c
+++ b/object.c
@@ -243,10 +243,10 @@ void drawChar(CELL pos, int color, const char character)
 	putchar(character);
 }
 
-void drawObjects(SNAKE snake, FRUIT fruit, int quit)
+void drawObjects(SNAKE snake, FRUIT fruit, bool quit)
 {
 	int i;
-	if (quit) 
+	if (quit == true) 
 	{
 		drawChar(snake.body[1], QUIT_COLOR, HEAD_SHAPE);	/* dead snake's head */
 		textcolor(TEXT_COLOR);					/* back to normal color */

--- a/object.h
+++ b/object.h
@@ -84,5 +84,5 @@ void createSnake(SCREEN screen, SNAKE* snake);
 void drawChar(CELL pos, int color, const char ch);
 
 /* draw snake and fruit into screen. need to check whether the game ends */
-void drawObjects(SNAKE snake, FRUIT fruit, int quit);
+void drawObjects(SNAKE snake, FRUIT fruit, bool quit);
 

--- a/object.h
+++ b/object.h
@@ -82,6 +82,6 @@ void createSnake(SCREEN screen, SNAKE* snake);
 /* draw one single 'character' at desired position 'pos' using 'color'*/
 void drawChar(CELL pos, int color, const char ch);
 
-/* draw snake and fruit into screen */
-void drawObjects(SNAKE snake, FRUIT fruit);
+/* draw snake and fruit into screen. need to check whether the game ends */
+void drawObjects(SNAKE snake, FRUIT fruit, int quit);
 

--- a/object.h
+++ b/object.h
@@ -7,6 +7,7 @@
 #define	FRUIT_SHAPE	'#'
 #define	HEAD_COLOR	15
 #define	BODY_COLOR	8
+#define QUIT_COLOR	12
 
 /* -- GAME LOGIC -- */
 typedef struct fruit


### PR DESCRIPTION
1. 게임 오버 시 clearGameScreen 함수로 화면을 지우지 않고 기존 화면을 남겨두도록 조건 추가
2. drawObjects 함수가 죽기 직전 상태를 보존하고, 머리를 빨간색으로 칠함.
3. 빨간색을 매크로 변수 QUIT_COLOR로 정의 후 적용

#39 이슈의 논의 과정을 토대로 변경되었습니다.